### PR TITLE
Adding GPG key for apt repo

### DIFF
--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -7,6 +7,8 @@ when 'debian'
 
   apt_repository 'thoughtworks' do
     uri 'http://dl.bintray.com/gocd/gocd-deb/'
+    keyserver "pgp.mit.edu"
+    key "0x9149B0A6173454C7"
     components ['/']
   end
 


### PR DESCRIPTION
Fixes https://github.com/ThoughtWorksInc/go-cookbook/issues/39