### PR TITLE
Increased VM memory allocation in Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant::configure(api_version) do |config|
     linux.vm.box_url           = linux_box_url
 
     linux.vm.provider :virtualbox do |v|
-      v.customize ['modifyvm', :id, '--memory', '1024']
+      v.customize ['modifyvm', :id, '--memory', '2048']
     end
 
     linux.vm.network "forwarded_port", guest:8153, host: 8153


### PR DESCRIPTION
The VM memory spec was 1024MB, which seemed a wee bit tight.  After installing Git on the VM, there was not enough free memory to call it from Go!  Increasing to 2048MB gives it a bit more breathing room.