### PR TITLE
added instruction for go server start with recipe in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ It's primarily tested on newer versions of Ubuntu, but should work on both Debia
 
 go::server will install and start an empty Go server.
 
+Before running chef-client with this recipe , ensure you have the
+following setting on your server else server start will fail
+
+$ hostname 
+<server-hostname>
+
+$ vim /etc/hosts
+127.0.0.1 <server-hostname>
+
 # Go Agent
 
 ## Linux


### PR DESCRIPTION
If we try to create a go server with go recipe , it fails in server start operation.
The server on which chef-client is being run should have a valid hostname with related entry in /etc/hosts file/